### PR TITLE
Annotate `string` type to resolved value from `Promise`

### DIFF
--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -38,7 +38,7 @@ describe('index', () => {
     process.env['INPUT_PARENT_ID'] = 'parentId'
     process.env['INPUT_DEST_FILE_NAME'] = 'destFileName'
     process.env['INPUT_SRC_FILE_NAME'] = ''
-    const [stdout, stderr] = await new Promise((resolve) => {
+    const [stdout, stderr]: [string, string] = await new Promise((resolve) => {
       cp.exec(`node ${ip}`, { env: process.env }, (_err, stdout, stderr) => {
         resolve([stdout.toString(), stderr.toString()])
       })


### PR DESCRIPTION
It avoid following error in TypeScript 4.8.2.

Error: [tsl] ERROR in /workspaces/gdrive-act-recv/test/index.spec.ts(41,11)
TS2488: Type 'unknown' must have a '[Symbol.iterator]()' method that returns an iterator.
