### PR TITLE
ci: Use Node.js 24.x in test workflow

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -14,10 +14,10 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - name: Use Node.js 26.x
+      - name: Use Node.js 24.x
         uses: actions/setup-node@v7
         with:
-          node-version: 26.x
+          node-version: 24.x
 
       - name: Cache node modules
         uses: actions/cache@v6


### PR DESCRIPTION
node24 の action なのでテストも 24.x で実行するように変更。
